### PR TITLE
[codex] Fix purchase invoice validation

### DIFF
--- a/__tests__/stubs/createDocument.data.ts
+++ b/__tests__/stubs/createDocument.data.ts
@@ -108,3 +108,37 @@ export const TEInputExample: CreateDocumentInput['document'] = {
   paymentMethod: '03',
   conditionSale: '01'
 }
+
+export const FECInputExample: CreateDocumentInput['document'] = {
+  consecutiveIdentifier: '2',
+  activityCode: '729001',
+  providerId: emitterStub.identifier.id,
+  documentName: 'FacturaElectronicaCompra',
+  branch: '1',
+  terminal: '1',
+  ceSituation: '1',
+  countryCode: '506',
+  emitter: {
+    fullName: 'Airbnb',
+    commercialName: 'Airbnb',
+    activityCode: '729001',
+    identifier: {
+      type: '05',
+      id: '000000000001'
+    },
+    foreignAddress: 'Proveedor extranjero no domiciliado',
+    email: 'no-reply@airbnb.com'
+  },
+  receiver: receiverStub,
+  orderLines,
+  securityCode: '1',
+  paymentMethod: '04',
+  conditionSale: '01',
+  referenceInfo: {
+    docType: '16',
+    refNumber: 'HMX5HK4SNQ',
+    issueDate: new Date(),
+    code: '11',
+    reason: 'Proveedor no domiciliado - comision Airbnb'
+  }
+}

--- a/__tests__/tests/ATV/create-document.test.ts
+++ b/__tests__/tests/ATV/create-document.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import { ATV } from '@src/ATV'
 import 'jest-xml-matcher'
-import { FEInputExample } from '@test/stubs/createDocument.data'
+import { FECInputExample, FEInputExample } from '@test/stubs/createDocument.data'
 const fakePem = fs.readFileSync('__tests__/stubs/dummyKeys/client-identity.p12', 'binary')
 const fakePassword = '1234'
 const expectXml = fs.readFileSync('__tests__/stubs/commonExpectedXml.xml', 'utf-8')
@@ -55,5 +55,38 @@ describe('Create Document (Invoice)', () => {
       signatureOptions: undefined
     })
     expect(createdDoc.extraData.xml).toEqualXML(expectXml)
+  })
+
+  it('should create a purchase invoice without factory-assumed tax fields', async () => {
+    const atv = new ATV({}, 'stg')
+    const createdDoc = await atv.createDocumentCommand({
+      document: FECInputExample,
+      token: 'fake-token',
+      // @ts-expect-error only for testing
+      signatureOptions: undefined
+    })
+
+    expect(createdDoc.extraData.xml).toContain('<FacturaElectronicaCompra')
+    expect(createdDoc.extraData.xml).toContain('<ImpuestoNeto>')
+    expect(createdDoc.extraData.xml).not.toContain('<ImpuestoAsumidoEmisorFabrica>')
+    expect(createdDoc.extraData.xml).not.toContain('<TotalImpAsumEmisorFabrica>')
+  })
+
+  it('should create a purchase invoice key and activity from the signing receiver', async () => {
+    const receiver = FECInputExample.receiver
+    if (!receiver) throw new Error('FECInputExample.receiver is required')
+
+    const atv = new ATV({}, 'stg')
+    const createdDoc = await atv.createDocumentCommand({
+      document: FECInputExample,
+      token: 'fake-token',
+      // @ts-expect-error only for testing
+      signatureOptions: undefined
+    })
+
+    expect(createdDoc.command.data.clave).toContain(receiver.identifier.id.padStart(12, '0'))
+    expect(createdDoc.extraData.xml).toContain(`<CodigoActividadEmisor>${receiver.activityCode.padStart(6, '0')}</CodigoActividadEmisor>`)
+    expect(createdDoc.extraData.xml).toContain(`<Numero>${FECInputExample.emitter.identifier.id}</Numero>`)
+    expect(createdDoc.extraData.xml).toContain(`<Numero>${receiver.identifier.id}</Numero>`)
   })
 })

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,11 @@ Para probar crear y enviar tiquete electronico. Ejemplo:
 yarn ts-node -r tsconfig-paths/register --require dotenv/config examples/createAndSendTE.ts 1
 ```
 
+Para probar crear y enviar factura electronica de compra. Ejemplo:
+```
+yarn ts-node -r tsconfig-paths/register --require dotenv/config examples/createAndSendFEC.ts 1
+```
+
 Para aceptar una factura. Ejemplo:
 ```
 yarn ts-node -r tsconfig-paths/register --require dotenv/config examples/atvAccept.ts

--- a/examples/createAndSendFEC.ts
+++ b/examples/createAndSendFEC.ts
@@ -1,0 +1,94 @@
+import fs from 'fs'
+import { FECInputExample } from '@test/stubs/createDocument.data'
+import { ATV } from '../dist/src'
+import { PersonProps } from 'dist/src/ATV/core/Person'
+
+const getRequiredEnv = (key: string): string => {
+  const value = process.env[key]
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${key}`)
+  }
+  return value
+}
+
+const USERNAME_TEST = getRequiredEnv('USERNAME_TEST')
+const PASSWORD_TEST = getRequiredEnv('PASSWORD_TEST')
+const EMITTER_IDENTIFIER_ID = getRequiredEnv('EMITTER_IDENTIFIER_ID')
+const EMITTER_IDENTIFIER_TYPE = getRequiredEnv('EMITTER_IDENTIFIER_TYPE') as PersonProps['identifier']['type']
+
+const SOURCE_P12_URI = getRequiredEnv('SOURCE_P12_URI')
+const SOURCE_P12_PASSPORT = getRequiredEnv('SOURCE_P12_PASSPORT')
+
+const pem = fs.readFileSync(SOURCE_P12_URI, 'binary')
+
+const paramConsecutive = process.argv[2]
+const consecutiveIdentifier = paramConsecutive || process.env.TEST_CONSECUTIVE
+console.log('paramConsecutive', paramConsecutive)
+
+// In FacturaElectronicaCompra the non-domiciled supplier is XML Emisor,
+// and the local taxpayer/business that signs is XML Receptor.
+const receiver = FECInputExample.receiver
+if (!receiver) {
+  throw new Error('FECInputExample.receiver is required')
+}
+
+if (!consecutiveIdentifier) {
+  throw new Error('Missing consecutiveIdentifier. Pass it as argument or set TEST_CONSECUTIVE.')
+}
+
+FECInputExample.consecutiveIdentifier = consecutiveIdentifier
+receiver.identifier.id = EMITTER_IDENTIFIER_ID
+receiver.identifier.type = EMITTER_IDENTIFIER_TYPE
+FECInputExample.providerId = EMITTER_IDENTIFIER_ID
+
+console.log('requestStub consecutivo', FECInputExample.consecutiveIdentifier)
+
+function getConfimation(atv: ATV, token: string, location: string, ms: number): Promise<Awaited<ReturnType<ATV['sendConfirmation']>>> {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      console.log('location', location)
+      atv.sendConfirmation({
+        url: location,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'bearer ' + token
+        }
+      }).then(data => resolve(data))
+        .catch(err => reject(err))
+    }, ms)
+  })
+}
+
+async function main(): Promise<void> {
+  const atv = new ATV({}, 'stg')
+  const tokenData = await atv.getToken({
+    username: USERNAME_TEST,
+    password: PASSWORD_TEST
+  })
+  const { command, extraData } = await atv.createDocumentCommand({
+    document: FECInputExample,
+    token: tokenData.accessToken,
+    signatureOptions: {
+      buffer: pem,
+      password: SOURCE_P12_PASSPORT
+    }
+  })
+  console.log({
+    clave: command.data.clave,
+    emisor: command.data.emisor,
+    receptor: command.data.receptor,
+    hasImpuestoAsumidoEmisorFabrica: extraData.xml.includes('ImpuestoAsumidoEmisorFabrica')
+  })
+  const response = await atv.sendDocument(command)
+  if (response.errorCause) {
+    console.log('error response', response)
+    return
+  }
+  if (!response.location) {
+    throw new Error('No confirmation location returned by Hacienda.')
+  }
+  const confirmationResponse = await getConfimation(atv, tokenData.accessToken, response.location, 3500)
+  console.log({ MensajeHacienda: confirmationResponse.confirmation })
+}
+
+main()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@facturacr/atv-sdk",
-  "version": "2.0.13-alpha",
+  "version": "2.0.14-alpha",
   "description": "Librería (SDK) de Javascript/NodeJS para acceder al API de Administración Tributaria Virtual (ATV) del Ministerio de Hacienda.",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/ATV/core/CreateDocFactory.ts
+++ b/src/ATV/core/CreateDocFactory.ts
@@ -119,14 +119,18 @@ export class CreateDocFactory {
   }
 
   private createClave(dto: CreateDocumentInput['document'], docType: DocumentType): Clave {
+    const keyPerson = dto.documentName === 'FacturaElectronicaCompra' && dto.receiver
+      ? dto.receiver
+      : dto.emitter
+
     return Clave.create({
       branch: dto.branch,
       ceSituation: dto.ceSituation,
       consecutiveIdentifier: dto.consecutiveIdentifier,
       countryCode: dto.countryCode,
       docKeyType: docType.value,
-      emitterIdentifier: dto.emitter.identifier.id,
-      identifierType: dto.emitter.identifier.type || '01',
+      emitterIdentifier: keyPerson.identifier.id,
+      identifierType: keyPerson.identifier.type || '01',
       securityCode: dto.securityCode,
       terminal: dto.terminal
     })

--- a/src/ATV/mappers/billDocToAtv.ts
+++ b/src/ATV/mappers/billDocToAtv.ts
@@ -11,7 +11,9 @@ const parseAtvMoneyFormat = (amount: number) => {
   return parseFloat(amount.toFixed(5))
 }
 
-const mapOrderLinesToAtvFormat = (orderLines: OrderLine[]): DetalleServicio => {
+const isPurchaseInvoice = (docName: string) => docName === 'FacturaElectronicaCompra'
+
+const mapOrderLinesToAtvFormat = (orderLines: OrderLine[], docName: string): DetalleServicio => {
   const LineaDetalle = orderLines.map<DetalleServicio['LineaDetalle'][0]>((orderLine) => {
     const impuestoMonto = orderLine.tax ? parseAtvMoneyFormat(orderLine.tax.amount ?? 0) : 0
     return {
@@ -36,7 +38,9 @@ const mapOrderLinesToAtvFormat = (orderLines: OrderLine[]): DetalleServicio => {
           // Exoneracion is explicitly excluded here
         }
       }),
-      ImpuestoAsumidoEmisorFabrica: 0,
+      ...(!isPurchaseInvoice(docName) && {
+        ImpuestoAsumidoEmisorFabrica: 0
+      }),
       // @ts-expect-error pending-to-fix
       ImpuestoNeto: parseAtvMoneyFormat(orderLine.tax.amount),
       MontoTotalLinea: parseAtvMoneyFormat(orderLine.totalOrderLineAmount),
@@ -47,7 +51,7 @@ const mapOrderLinesToAtvFormat = (orderLines: OrderLine[]): DetalleServicio => {
   return { LineaDetalle }
 }
 
-const mapSummaryInvoice = (document: DomainDocument): Resumen => {
+const mapSummaryInvoice = (document: DomainDocument, docName: string): Resumen => {
   const summaryInvoice = document.summaryInvoice
   const orderLines = document.orderLines // Still need access to order lines for breakdown
 
@@ -97,7 +101,9 @@ const mapSummaryInvoice = (document: DomainDocument): Resumen => {
     TotalVentaNeta: parseAtvMoneyFormat(summaryInvoice.totalNetSale),
     TotalDesgloseImpuesto,
     TotalImpuesto: parseAtvMoneyFormat(summaryInvoice.totalTaxes),
-    TotalImpAsumEmisorFabrica: 0,
+    ...(!isPurchaseInvoice(docName) && {
+      TotalImpAsumEmisorFabrica: 0
+    }),
     TotalOtrosCargos: 0,
     MedioPago: {
       // @ts-expect-error pending-to-fix
@@ -153,10 +159,13 @@ const mapReferenceInformation = (referenceInfo: ReferenceInformation): Informaci
 
 export const mapDocumentToAtvFormat = (docName: string, document: DomainDocument): AtvFormat => {
   const key = docName
+  const activitySource = isPurchaseInvoice(docName) && document.receiver
+    ? document.receiver
+    : document.emitter
   const doc: AtvDocument = {
     Clave: document.clave,
     ProveedorSistemas: document.providerId,
-    CodigoActividadEmisor: document.emitter.activityCode.padStart(6, '0'),
+    CodigoActividadEmisor: activitySource.activityCode.padStart(6, '0'),
     ...(document.receiver && { // TODO add && document.name === 'FacturaElectronica'
       CodigoActividadReceptor: document.receiver?.activityCode?.padStart(6, '0')
     }),
@@ -168,8 +177,8 @@ export const mapDocumentToAtvFormat = (docName: string, document: DomainDocument
     }),
     CondicionVenta: document.conditionSale,
     PlazoCredito: document.deadlineCredit,
-    DetalleServicio: mapOrderLinesToAtvFormat(document.orderLines),
-    ResumenFactura: mapSummaryInvoice(document),
+    DetalleServicio: mapOrderLinesToAtvFormat(document.orderLines, docName),
+    ResumenFactura: mapSummaryInvoice(document, docName),
     Otros: document.others
   }
   if (document.referenceInformation) {


### PR DESCRIPTION
## Summary

- Fixes Factura Electronica de Compra generation for non-domiciled provider flows.
- Keeps Airbnb/non-domiciled supplier as XML `Emisor` and the local signing taxpayer as XML `Receptor`.
- Uses the signing receiver for the FEC key and activity validation while leaving normal FE/TE/NC behavior unchanged.
- Omits factory-assumed tax fields that are invalid for FEC v4.4.
- Adds a sandbox example runner for FEC and unit coverage for the new behavior.

## Validation

- `yarn lint`
- `npm test -- --runInBand`
- `npm run build`
- `npm run type:check`
- Manual Hacienda sandbox FEC test returned accepted state (`message: "1"`).

## Notes

This is scoped to `FacturaElectronicaCompra`; FE, TE and NC continue using their original key/document behavior.