### PR TITLE
[codex] Fix FEC reference order

### DIFF
--- a/__tests__/tests/ATV/create-document.test.ts
+++ b/__tests__/tests/ATV/create-document.test.ts
@@ -2,6 +2,13 @@ import fs from 'fs'
 import { ATV } from '@src/ATV'
 import 'jest-xml-matcher'
 import { FECInputExample, FEInputExample } from '@test/stubs/createDocument.data'
+import { Clave } from '@src/ATV/core/Clave'
+import { Document as DomainDocument } from '@src/ATV/core/Document'
+import { FullConsecutive } from '@src/ATV/core/FullConsecutive'
+import { OrderLine } from '@src/ATV/core/OrderLine'
+import { Person } from '@src/ATV/core/Person'
+import { ReferenceInformation } from '@src/ATV/core/ReferenceInformation'
+import { mapDocumentToAtvFormat } from '@src/ATV/mappers/billDocToAtv'
 const fakePem = fs.readFileSync('__tests__/stubs/dummyKeys/client-identity.p12', 'binary')
 const fakePassword = '1234'
 const expectXml = fs.readFileSync('__tests__/stubs/commonExpectedXml.xml', 'utf-8')
@@ -70,6 +77,58 @@ describe('Create Document (Invoice)', () => {
     expect(createdDoc.extraData.xml).toContain('<ImpuestoNeto>')
     expect(createdDoc.extraData.xml).not.toContain('<ImpuestoAsumidoEmisorFabrica>')
     expect(createdDoc.extraData.xml).not.toContain('<TotalImpAsumEmisorFabrica>')
+  })
+
+  it('should place purchase invoice reference information before other text', async () => {
+    const receiver = FECInputExample.receiver
+    const referenceInfo = FECInputExample.referenceInfo
+    if (!receiver || !referenceInfo) throw new Error('FECInputExample receiver and referenceInfo are required')
+
+    const document = DomainDocument.create({
+      clave: Clave.create({
+        branch: FECInputExample.branch,
+        ceSituation: FECInputExample.ceSituation,
+        consecutiveIdentifier: FECInputExample.consecutiveIdentifier,
+        countryCode: FECInputExample.countryCode,
+        docKeyType: 'FEC',
+        emitterIdentifier: receiver.identifier.id,
+        identifierType: receiver.identifier.type || '01',
+        securityCode: FECInputExample.securityCode,
+        terminal: FECInputExample.terminal
+      }),
+      fullConsecutive: FullConsecutive.create({
+        consecutiveIdentifier: FECInputExample.consecutiveIdentifier,
+        branch: FECInputExample.branch,
+        terminal: FECInputExample.terminal,
+        documentType: 'FEC'
+      }),
+      orderLines: FECInputExample.orderLines.map((orderLine, index) => OrderLine.create({
+        detail: orderLine.detail,
+        unitaryPrice: orderLine.unitaryPrice,
+        lineNumber: orderLine.lineNumber || (index + 1).toString(),
+        code: orderLine.code,
+        quantity: orderLine.quantity,
+        measureUnit: orderLine.measureUnit,
+        totalAmount: orderLine.totalAmount,
+        tax: orderLine.tax
+      })),
+      providerId: FECInputExample.providerId,
+      issueDate: new Date(),
+      emitter: Person.create(FECInputExample.emitter),
+      receiver: Person.create(receiver),
+      conditionSale: FECInputExample.conditionSale,
+      paymentMethod: FECInputExample.paymentMethod,
+      referenceInformation: ReferenceInformation.create(referenceInfo),
+      others: {
+        OtroTexto: 'Factura Electronica de Compra generada automaticamente.'
+      }
+    })
+    const createdDoc = mapDocumentToAtvFormat('FacturaElectronicaCompra', document)
+    const keys = Object.keys(createdDoc.FacturaElectronicaCompra)
+
+    expect(keys.indexOf('InformacionReferencia')).toBeGreaterThan(-1)
+    expect(keys.indexOf('Otros')).toBeGreaterThan(-1)
+    expect(keys.indexOf('InformacionReferencia')).toBeLessThan(keys.indexOf('Otros'))
   })
 
   it('should create a purchase invoice key and activity from the signing receiver', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@facturacr/atv-sdk",
-  "version": "2.0.14-alpha",
+  "version": "2.0.15-alpha",
   "description": "Librería (SDK) de Javascript/NodeJS para acceder al API de Administración Tributaria Virtual (ATV) del Ministerio de Hacienda.",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/ATV/mappers/billDocToAtv.ts
+++ b/src/ATV/mappers/billDocToAtv.ts
@@ -179,10 +179,10 @@ export const mapDocumentToAtvFormat = (docName: string, document: DomainDocument
     PlazoCredito: document.deadlineCredit,
     DetalleServicio: mapOrderLinesToAtvFormat(document.orderLines, docName),
     ResumenFactura: mapSummaryInvoice(document, docName),
+    ...(document.referenceInformation && {
+      InformacionReferencia: mapReferenceInformation(document.referenceInformation)
+    }),
     Otros: document.others
-  }
-  if (document.referenceInformation) {
-    doc.InformacionReferencia = mapReferenceInformation(document.referenceInformation)
   }
   return {
     [key]: doc


### PR DESCRIPTION
## Summary

- Bumps `@facturacr/atv-sdk` to `2.0.15-alpha`.
- Places `InformacionReferencia` before `Otros` for purchase invoice XML generation.
- Keeps previous FEC fixes for omitted factory-assumed tax fields and signing receiver key/activity behavior.
- Adds regression coverage for the FEC reference/order requirement.

## Validation

- `yarn lint`
- `npm test -- --runInBand`
- `npm run build`
- `npm run type:check`

## Context

Hacienda rejected the latest FEC because the XML had `<Otros>` before `<InformacionReferencia>`. The v4.4 FEC schema expects `InformacionReferencia` before `Otros`.